### PR TITLE
Fixed a bug where passing an uppercase difficulty doesn't work

### DIFF
--- a/src/FakeSudokuPuzzleGenerator.ts
+++ b/src/FakeSudokuPuzzleGenerator.ts
@@ -90,7 +90,7 @@ export type Difficulty = "VeryEasy" | "Easy" | "Medium" | "Hard";
  * @Return {(number | null)[][];}
  */
 export const getSudoku = function(difficulty: Difficulty): SudokuNumber[][] {
-  switch (difficulty + "".toLowerCase()) {
+  switch ((difficulty + "").toLowerCase()) {
     case "veryeasy":
       return getVeryEasySudoku();
     case "easy":


### PR DESCRIPTION
`difficulty + "".toLowerCase()` would only lowercase the empty string, not the difficulty